### PR TITLE
bug fixed: correcting logic of getting project details

### DIFF
--- a/src/features/projects/ProjectDetails.jsx
+++ b/src/features/projects/ProjectDetails.jsx
@@ -1,14 +1,13 @@
 import { useNavigate, useParams } from "react-router";
+import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
+
 import { useProjectDetail } from "./useProjectDetail";
-import { useProjectMembers } from "./useProjectMembers";
 import { useJoinProject } from "./useJoinProject";
 import { formatDate } from "../../utils/helper";
-import { useGetUserDetail } from "../user/useGetUserDetail";
-import { useRequiredSkills } from "./useRequiredSkills";
+
 import Loader from "../../ui/Loader";
 import Button from "../../ui/Button";
-import { useSelector } from "react-redux";
 
 function ProjectDetails() {
   //TODO get userId from auth context
@@ -19,28 +18,22 @@ function ProjectDetails() {
   const { projectId } = useParams();
   const navigate = useNavigate();
 
-  const { details, error, isLoading } = useProjectDetail(projectId);
-  const { mutateJoinProject, isJoining } = useJoinProject();
+  const { details, projectMembers, owner, skills, isLoading } =
+    useProjectDetail(projectId);
 
   const {
-    description,
     title,
-    created_by,
-    place,
-    repository,
-    visibility,
-    created_at,
-    status,
+    description,
     projectSummary,
+    created_at,
+    place,
+    visibility,
+    repository,
   } = details?.[0] || {};
 
-  const { projectMembers } = useProjectMembers(projectId);
-  const { user: owner } = useGetUserDetail(created_by);
   const { name: ownerName, email: ownerEmail, id: ownerId } = owner?.[0] || {};
 
-  const { skills } = useRequiredSkills(projectId);
-  console.log(skills);
-  console.log(projectId);
+  const { mutateJoinProject, isJoining } = useJoinProject();
 
   function handleNavigateBack() {
     navigate(-1);

--- a/src/features/projects/useProjectDetail.js
+++ b/src/features/projects/useProjectDetail.js
@@ -1,15 +1,34 @@
 import { useQuery } from "@tanstack/react-query";
-
-import { getProjectDetail } from "../../services/apiProject";
+import {
+  getProjectDetail,
+  getProjectMembers,
+  getProjectSkill,
+} from "../../services/apiProject";
+import { getUserDetail } from "../../services/apiUser";
 
 export function useProjectDetail(projectId) {
-  const {
-    data: details,
-    error,
-    isLoading,
-  } = useQuery({
-    queryKey: ["projects"],
+  const { data: details, isLoading } = useQuery({
+    queryKey: ["projectDetails", projectId],
     queryFn: () => getProjectDetail(projectId),
   });
-  return { details, error, isLoading };
+
+  const { data: projectMembers } = useQuery({
+    queryKey: ["projectMembers", projectId],
+    queryFn: () => getProjectMembers(projectId),
+    enabled: !!projectId, // Ensure projectId is available before fetching
+  });
+
+  const { data: owner } = useQuery({
+    queryKey: ["owner", details?.[0]?.created_by],
+    queryFn: () => getUserDetail(details?.[0]?.created_by),
+    enabled: !!details?.[0]?.created_by, // Only fetch owner after details are loaded
+  });
+
+  const { data: skills } = useQuery({
+    queryKey: ["skills", projectId],
+    queryFn: () => getProjectSkill(projectId),
+    enabled: !!projectId, // Ensure projectId is available before fetching
+  });
+
+  return { details, projectMembers, owner, skills, isLoading };
 }


### PR DESCRIPTION
### Details
- Current Situation: When the project details of a particular project are loaded, a user state is created, which holds the project owner's information. However, when details of a new project are loaded, the `user` `state` does not update because the `state` is not properly managed.

### Updated Logic
- I have now centralized the logic for fetching the entire project details in the `useProjectDetail` hook. Additionally, I have ensured that the `projectId` is passed to each `query`, so that whenever the `projectId` is updated, the corresponding state is also updated accordingly.